### PR TITLE
Dirty fix of "revisions" issue

### DIFF
--- a/custom-permalinks.php
+++ b/custom-permalinks.php
@@ -435,7 +435,14 @@ function custom_permalinks_save_post($id) {
 	if ( !isset($_REQUEST['custom_permalinks_edit']) ) return;
 	
 	delete_post_meta( $id, 'custom_permalink' );
-	
+
+	// http://wordpress.org/support/topic/404-error-potentially-caused-by-revisions
+	// not sure why we should create permalinks on something except actual version of post/page
+	// so... quick and dirty - remove revision's premalink if exists but don't create a new one
+	if (isset($_REQUEST['post_ID']) && $id != $_REQUEST['post_ID']) {
+        return;
+    }	
+
 	$original_link = custom_permalinks_original_post_link($id);
 	$permalink_structure = get_option('permalink_structure');
 	

--- a/custom-permalinks.php
+++ b/custom-permalinks.php
@@ -121,7 +121,7 @@ function custom_permalinks_redirect() {
 		// Request doesn't match permalink - redirect
 		$url = $custom_permalink;
 
-		if ( substr($request, 0, strlen($original_permalink)) == $original_permalink &&
+		if ( '' != $original_permalink && substr($request, 0, strlen($original_permalink)) == $original_permalink &&
 				trim($request,'/') != trim($original_permalink,'/') ) {
 			// This is the original link; we can use this url to derive the new one
 			$url = preg_replace('@//*@', '/', str_replace(trim($original_permalink,'/'), trim($custom_permalink,'/'), $request));


### PR DESCRIPTION
http://wordpress.org/support/topic/404-error-potentially-caused-by-revisions

In some cases "custom permalink" creates TWO permalinks with same url:
one for a post/page and another one on this post/page's revision. This fix 
avoids saving of permalinks on revisions and maybe on something else... :")

Works perfect for me, but didn't tested well on all cases. So may corrupt 
something else :")
